### PR TITLE
Add `setFromRequest` action handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ Api and middleware for redux applications. While configurable, the basics are:
 ---
 
 ## Contents
-+ [Quick Start - Middleware](#Quick Start - Middleware)
- + [Install](#Install)
- + [Action Creator](#Action Creator)
-+ [Quick Start - Api](#Quick Start - Api)
-+ [Docs](#Docs)
- + [Middleware Configuration](#Middleware Configuration)
- + [Action](#Action)
++ [Quick Start - Middleware](#quick-start---middleware)
+ + [Install](#install)
+ + [Action Creator](#action-creator)
++ [Quick Start - Api](#quick-start---api)
++ [Docs](#docs)
+ + [Middleware Configuration](#middleware-configuration)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[ ![Codeship Status for LaunchPadLab/lp-redux-api](https://app.codeship.com/projects/5b514ba0-ebe2-0134-f96d-2efd70753ac1/status?branch=master)](https://app.codeship.com/projects/208187)
+
 # lp-redux-api
 Api and middleware for redux applications. While configurable, the basics are:
 + Uses `isomorphic-fetch` under the hood

--- a/__mocks__/isomorphic-fetch.js
+++ b/__mocks__/isomorphic-fetch.js
@@ -2,9 +2,11 @@ export const successUrl = '/success'
 export const failureUrl = '/failure'
 export const networkErrorUrl = '/network-error'
 
+export const responseBody = { test: true }
+
 export default jest.fn(function (url) {
   const response = { 
-    json: () => Promise.resolve({}),
+    json: () => Promise.resolve(responseBody),
     ok: (url !== failureUrl) 
   }
   // Simulate server response

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "redux middleware and api library",
   "main": "lib/index.js",
   "scripts": {
+    "start": "yarn run build:development",
     "build": "mkdir -p lib && babel src --out-dir lib --no-comments --minified",
+    "build:development": "mkdir -p lib && babel src --watch --out-dir lib",
     "clean": "rimraf lib",
-    "dev": "mkdir -p lib && babel src --watch --out-dir lib",
     "lint": "eslint src",
-    "prepublish": "npm run lint && npm run clean && npm run build",
+    "prepublish": "yarn run lint && yarn run clean && yarn run build",
     "test": "jest"
   },
   "repository": "launchpadlab/lp-redux-api",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-redux-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "redux middleware and api library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,10 +3,10 @@ export const LP_API_STATUS_LOADING = 'loading'
 export const LP_API_STATUS_SUCCESS = 'success'
 export const LP_API_STATUS_FAILURE = 'failure'
 
-function lpApiAction (key, status) {
+function lpApiAction (key, status, response={}) {
   return {
     type: LP_API_ACTION,
-    payload: { key, status }
+    payload: { key, status, response }
   }
 }
 
@@ -14,8 +14,8 @@ export function lpApiRequest (key) {
   return lpApiAction(key, LP_API_STATUS_LOADING)
 }
 
-export function lpApiSuccess (key) {
-  return lpApiAction(key, LP_API_STATUS_SUCCESS)
+export function lpApiSuccess (key, response) {
+  return lpApiAction(key, LP_API_STATUS_SUCCESS, response)
 }
 
 export function lpApiFailure (key) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,10 +3,10 @@ export const LP_API_STATUS_LOADING = 'loading'
 export const LP_API_STATUS_SUCCESS = 'success'
 export const LP_API_STATUS_FAILURE = 'failure'
 
-function lpApiAction (key, status, response=null) {
+function lpApiAction (key, status) {
   return {
     type: LP_API_ACTION,
-    payload: { key, status, response }
+    payload: { key, status }
   }
 }
 
@@ -14,8 +14,8 @@ export function lpApiRequest (key) {
   return lpApiAction(key, LP_API_STATUS_LOADING)
 }
 
-export function lpApiSuccess (key, response) {
-  return lpApiAction(key, LP_API_STATUS_SUCCESS, response)
+export function lpApiSuccess (key) {
+  return lpApiAction(key, LP_API_STATUS_SUCCESS)
 }
 
 export function lpApiFailure (key) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,7 +3,7 @@ export const LP_API_STATUS_LOADING = 'loading'
 export const LP_API_STATUS_SUCCESS = 'success'
 export const LP_API_STATUS_FAILURE = 'failure'
 
-function lpApiAction (key, status, response={}) {
+function lpApiAction (key, status, response=null) {
   return {
     type: LP_API_ACTION,
     payload: { key, status, response }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export * as api from './api'
+export { default as setFromRequest } from './set-from-request'
 export { default as http } from './http'
 export { default as HttpError } from './http-error'
 export { default as isAuthenticated } from './is-authenticated'

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
+export { 
+  LP_API_STATUS_LOADING, 
+  LP_API_STATUS_SUCCESS, 
+  LP_API_STATUS_FAILURE 
+} from './actions'
 export * as api from './api'
-export { default as setFromRequest } from './set-from-request'
 export { default as http } from './http'
 export { default as HttpError } from './http-error'
 export { default as isAuthenticated } from './is-authenticated'
 export { default as LP_API } from './LP_API'
 export { default as middleware } from './middleware'
 export { default as reducer, selectStatus } from './reducer'
-export { 
-  LP_API_STATUS_LOADING, 
-  LP_API_STATUS_SUCCESS, 
-  LP_API_STATUS_FAILURE 
-} from './actions'
+export { default as requestWithKey } from './request-with-key'
+export { default as setFromRequest } from './set-from-request'

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -38,26 +38,32 @@ export default function ({ onUnauthorized, ...options }) {
     }
 
     const {
+      actions,
+      types,
+      ...options
+    } = lpApi
+
+    // Alias 'actions' with 'types' for backwards compatibility
+    const actionTypes = actions || types || []
+    const [ requestFallback, successFallback, failureFallback ] = actionTypes
+
+    const {
+      url,
       body,
       credentials,
       csrf,
       headers,
       method,
       mode,
-      actions,
-      types,
-      url,
+      requestAction=requestFallback,
+      successAction=successFallback,
+      failureAction=failureFallback,
       requestKey='REQUEST',
       ...rest,
-    } = lpApi
-
-    // Alias 'actions' with 'types' for backwards compatibility
-    const actionTypes = actions || types
+    } = options
 
     // Make sure required options exist
-    validateOptions({ url, actionTypes })
-
-    const [ requestAction, successAction, failureAction ] = actionTypes
+    validateOptions({ url, actionTypes: [requestAction, successAction, failureAction] })
 
     // Send request action to API reducer
     next(lpApiRequest(requestKey))
@@ -120,7 +126,7 @@ export default function ({ onUnauthorized, ...options }) {
 
 function validateOptions ({ url, actionTypes }) {
   if (!url || typeof url !== 'string') throw 'Must provide string \'url\' argument'
-  if (!actionTypes || !Array.isArray(actionTypes)) throw 'Must provide an array of actions. Use \'api\' module for requests with no associated actions.'
+  if (!actionTypes.length) throw 'Must provide at least one action definition. Use \'api\' module for requests with no associated actions.'
 }
 
 // Create an action from an action "definition."

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -125,8 +125,8 @@ export default function ({ onUnauthorized, ...options }) {
 }
 
 function validateOptions ({ url, actionTypes }) {
-  if (!url || typeof url !== 'string') throw 'Must provide string \'url\' argument'
-  if (!actionTypes.length) throw 'Must provide at least one action definition. Use \'api\' module for requests with no associated actions.'
+  if (!url || typeof url !== 'string') throw `Must provide string 'url' argument`
+  if (!actionTypes.length) throw `Must provide at least one action definition. Use 'api' module for requests with no associated actions.`
 }
 
 // Create an action from an action "definition."

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -110,7 +110,7 @@ export default function ({ onUnauthorized, ...options }) {
       .then(response => {
 
         // Send success action to API reducer
-        next(lpApiSuccess(requestKey))
+        next(lpApiSuccess(requestKey, response))
 
         // Send user-specified success action
         if (successAction) {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -58,7 +58,7 @@ export default function ({ onUnauthorized, ...options }) {
       requestAction=requestFallback,
       successAction=successFallback,
       failureAction=failureFallback,
-      requestKey='REQUEST',
+      requestKey='DEFAULT_REQUEST_KEY',
       ...rest,
     } = options
 

--- a/src/request-with-key.js
+++ b/src/request-with-key.js
@@ -1,7 +1,7 @@
 import LP_API from './LP_API'
 
 export default function (requestKey, options={}) {
-  if (!requestKey) throw 'Must include \'requestKey\' argument'
+  if (!requestKey) throw `Must include 'requestKey' argument`
   return {
     [LP_API]: {
       ...options,

--- a/src/request-with-key.js
+++ b/src/request-with-key.js
@@ -1,0 +1,12 @@
+import LP_API from './LP_API'
+
+export default function (requestKey, options={}) {
+  if (!requestKey) throw 'Must include \'requestKey\' argument'
+  return {
+    [LP_API]: {
+      ...options,
+      requestKey,
+      actions: [`${requestKey}_REQUEST`, `${requestKey}_SUCCESS`, `${requestKey}_FAILURE`]
+    }
+  }
+}

--- a/src/set-from-request.js
+++ b/src/set-from-request.js
@@ -1,0 +1,14 @@
+import { set } from './utils'
+import { 
+  LP_API_ACTION
+} from './actions'
+
+export default function (path, requestKey) {
+  if (!path || !requestKey) throw 'Must include \'path\' and \'requestKey\' arguments.'
+  return {
+    [LP_API_ACTION]: function (state, { payload }) {
+      if (payload.key !== requestKey) return state
+      return set(path, payload.response, state)
+    }
+  }
+}

--- a/src/set-from-request.js
+++ b/src/set-from-request.js
@@ -1,8 +1,10 @@
-import { set } from './utils'
+import { set, unset, compose } from './utils'
 
 export default function (requestKey, path) {
+  const dataPath = `${path}.data`
+  const errorPath = `${path}.error`
   return {
-    [`${requestKey}_SUCCESS`]: (state, action) => set(path, action.payload, state),
-    [`${requestKey}_FAILURE`]: (state) => set(path, null, state)
+    [`${requestKey}_SUCCESS`]: (state, action) => compose(set(dataPath, action.payload), unset(errorPath))(state),
+    [`${requestKey}_FAILURE`]: (state, action) => compose(set(errorPath, action.payload), unset(dataPath))(state)
   }
 }

--- a/src/set-from-request.js
+++ b/src/set-from-request.js
@@ -1,15 +1,8 @@
 import { set } from './utils'
-import { 
-  LP_API_ACTION,
-  LP_API_STATUS_LOADING
-} from './actions'
 
 export default function (requestKey, path) {
-  if (!path || !requestKey) throw 'Must include \'path\' and \'requestKey\' arguments.'
   return {
-    [LP_API_ACTION]: function (state, { payload }) {
-      if (payload.key !== requestKey || payload.status === LP_API_STATUS_LOADING) return state
-      return set(path, payload.response, state)
-    }
+    [`${requestKey}_SUCCESS`]: (state, action) => set(path, action.payload, state),
+    [`${requestKey}_FAILURE`]: (state) => set(path, null, state)
   }
 }

--- a/src/set-from-request.js
+++ b/src/set-from-request.js
@@ -1,13 +1,14 @@
 import { set } from './utils'
 import { 
-  LP_API_ACTION
+  LP_API_ACTION,
+  LP_API_STATUS_LOADING
 } from './actions'
 
-export default function (path, requestKey) {
+export default function (requestKey, path) {
   if (!path || !requestKey) throw 'Must include \'path\' and \'requestKey\' arguments.'
   return {
     [LP_API_ACTION]: function (state, { payload }) {
-      if (payload.key !== requestKey) return state
+      if (payload.key !== requestKey || payload.status === LP_API_STATUS_LOADING) return state
       return set(path, payload.response, state)
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,7 @@ import isUndefined from 'lodash.isundefined'
 export { default as get } from 'lodash/fp/get'
 export { default as set } from 'lodash/fp/set'
 export { default as unset } from 'lodash/fp/unset'
+export { default as compose } from 'lodash/fp/compose'
 
 export function camelizeKeys (obj) {
   return humps.camelizeKeys(obj, (key, convert) =>
@@ -18,11 +19,4 @@ export function decamelizeKeys (obj) {
 
 export function omitUndefined (obj) {
   return omitBy(obj, isUndefined)
-}
-
-// Stolen from redux
-export function compose(...funcs) {
-  if (funcs.length === 0) return arg => arg
-  if (funcs.length === 1) return funcs[0]
-  return funcs.reduce((a, b) => (...args) => a(b(...args)))
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ import isUndefined from 'lodash.isundefined'
 
 export { default as get } from 'lodash/fp/get'
 export { default as set } from 'lodash/fp/set'
+export { default as unset } from 'lodash/fp/unset'
 
 export function camelizeKeys (obj) {
   return humps.camelizeKeys(obj, (key, convert) =>
@@ -17,4 +18,11 @@ export function decamelizeKeys (obj) {
 
 export function omitUndefined (obj) {
   return omitBy(obj, isUndefined)
+}
+
+// Stolen from redux
+export function compose(...funcs) {
+  if (funcs.length === 0) return arg => arg
+  if (funcs.length === 1) return funcs[0]
+  return funcs.reduce((a, b) => (...args) => a(b(...args)))
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,9 @@
 import humps from 'humps'
 import omitBy from 'lodash.omitby'
 import isUndefined from 'lodash.isundefined'
+
 export { default as get } from 'lodash/fp/get'
+export { default as set } from 'lodash/fp/set'
 
 export function camelizeKeys (obj) {
   return humps.camelizeKeys(obj, (key, convert) =>

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -14,7 +14,8 @@ test('REQUEST action creator creates action of expected type', () => {
     type: LP_API_ACTION,
     payload: {
       key: requestKey,
-      status: LP_API_STATUS_LOADING
+      status: LP_API_STATUS_LOADING,
+      response: null
     }
   }
   expect(lpApiRequest(requestKey)).toEqual(requestAction)
@@ -26,10 +27,11 @@ test('SUCCESS action creator creates action of expected type', () => {
     type: LP_API_ACTION,
     payload: {
       key: requestKey,
-      status: LP_API_STATUS_SUCCESS
+      status: LP_API_STATUS_SUCCESS,
+      response: 'response'
     }
   }
-  expect(lpApiSuccess(requestKey)).toEqual(requestAction)
+  expect(lpApiSuccess(requestKey, 'response')).toEqual(requestAction)
 })
 
 test('FAILURE action creator creates action of expected type', () => {
@@ -38,7 +40,8 @@ test('FAILURE action creator creates action of expected type', () => {
     type: LP_API_ACTION,
     payload: {
       key: requestKey,
-      status: LP_API_STATUS_FAILURE
+      status: LP_API_STATUS_FAILURE,
+      response: null
     }
   }
   expect(lpApiFailure(requestKey)).toEqual(requestAction)

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -14,8 +14,7 @@ test('REQUEST action creator creates action of expected type', () => {
     type: LP_API_ACTION,
     payload: {
       key: requestKey,
-      status: LP_API_STATUS_LOADING,
-      response: null
+      status: LP_API_STATUS_LOADING
     }
   }
   expect(lpApiRequest(requestKey)).toEqual(requestAction)
@@ -27,8 +26,7 @@ test('SUCCESS action creator creates action of expected type', () => {
     type: LP_API_ACTION,
     payload: {
       key: requestKey,
-      status: LP_API_STATUS_SUCCESS,
-      response: 'response'
+      status: LP_API_STATUS_SUCCESS
     }
   }
   expect(lpApiSuccess(requestKey, 'response')).toEqual(requestAction)
@@ -40,8 +38,7 @@ test('FAILURE action creator creates action of expected type', () => {
     type: LP_API_ACTION,
     payload: {
       key: requestKey,
-      status: LP_API_STATUS_FAILURE,
-      response: null
+      status: LP_API_STATUS_FAILURE
     }
   }
   expect(lpApiFailure(requestKey)).toEqual(requestAction)

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,18 @@
+/* FIXTURES */
+
+import { LP_API } from '../src'
+
+export const REQUEST_KEY = 'REQUEST_KEY'
+export const ACTION_TYPE_REQUEST = 'ACTION_TYPE_REQUEST'
+export const ACTION_TYPE_SUCCESS = 'ACTION_TYPE_SUCCESS'
+export const ACTION_TYPE_FAILURE = 'ACTION_TYPE_FAILURE'
+
+export const actionWithURL = (url) => {
+  return {
+    [LP_API]: {
+      url,
+      requestKey: REQUEST_KEY,
+      actions: [ACTION_TYPE_REQUEST, ACTION_TYPE_SUCCESS, ACTION_TYPE_FAILURE]
+    }
+  }
+}

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,8 +1,16 @@
 jest.mock('isomorphic-fetch')
 
-import { successUrl, failureUrl, networkErrorUrl } from 'isomorphic-fetch'
+import { successUrl, failureUrl, networkErrorUrl, responseBody } from 'isomorphic-fetch'
 import { middleware, LP_API } from '../src'
 import { lpApiRequest, lpApiSuccess, lpApiFailure } from '../src/actions'
+
+import {
+  REQUEST_KEY,
+  ACTION_TYPE_REQUEST,
+  ACTION_TYPE_SUCCESS,
+  ACTION_TYPE_FAILURE,
+  actionWithURL
+} from './fixtures'
 
 const configuredMiddleware = middleware({})
 
@@ -20,23 +28,6 @@ const callMiddleware = (action, opt={}) => {
     }
     return configuredMiddleware()(next)(action)
   })
-}
-
-/* FIXTURES */
-
-const REQUEST_KEY = 'REQUEST_KEY'
-const ACTION_TYPE_REQUEST = 'ACTION_TYPE_REQUEST'
-const ACTION_TYPE_SUCCESS = 'ACTION_TYPE_SUCCESS'
-const ACTION_TYPE_FAILURE = 'ACTION_TYPE_FAILURE'
-
-const actionWithURL = (url) => {
-  return {
-    [LP_API]: {
-      url,
-      requestKey: REQUEST_KEY,
-      actions: [ACTION_TYPE_REQUEST, ACTION_TYPE_SUCCESS, ACTION_TYPE_FAILURE]
-    }
-  }
 }
 
 /* TESTS */
@@ -67,7 +58,7 @@ test('middleware dispatches user-defined REQUEST action', () => {
 test('middleware dispatches reducer SUCCESS action', () => {
   return callMiddleware(actionWithURL(successUrl), { waitForActions: 3 }).then((actions) => {
     const apiSuccessAction = actions.pop()
-    expect(apiSuccessAction).toEqual(lpApiSuccess(REQUEST_KEY))
+    expect(apiSuccessAction).toEqual(lpApiSuccess(REQUEST_KEY, responseBody))
   })
 })
 

--- a/test/request-with-key.test.js
+++ b/test/request-with-key.test.js
@@ -1,0 +1,30 @@
+import { requestWithKey, LP_API } from '../src/'
+import { REQUEST_KEY } from './fixtures'
+
+// /* TESTS */
+
+test('requestWithKey requires a request key argument', () => {
+  expect(requestWithKey).toThrow()
+})
+
+test('requestWithKey fills in request key and action options correctly', () => {
+  const action = requestWithKey(REQUEST_KEY)
+  const expectedOptions = {
+    requestKey: REQUEST_KEY,
+    actions: [`${REQUEST_KEY}_REQUEST`, `${REQUEST_KEY}_SUCCESS`, `${REQUEST_KEY}_FAILURE`]
+  }
+  expect(action[LP_API]).toEqual(expectedOptions)
+})
+
+test('requestWithKey merges action options correctly', () => {
+  const action = requestWithKey(REQUEST_KEY, {
+    url: '/not-overridden',
+    actions: ['should', 'be', 'overridden']
+  })
+  const expectedOptions = {
+    url: '/not-overridden',
+    requestKey: REQUEST_KEY,
+    actions: [`${REQUEST_KEY}_REQUEST`, `${REQUEST_KEY}_SUCCESS`, `${REQUEST_KEY}_FAILURE`]
+  }
+  expect(action[LP_API]).toEqual(expectedOptions)
+})

--- a/test/set-from-request.test.js
+++ b/test/set-from-request.test.js
@@ -8,11 +8,13 @@ import { REQUEST_KEY } from './fixtures'
 
 /* HELPERS */
 
-const DATA_PATH = 'path.to.data'
+const PATH = 'path'
+const DATA_PATH = `${PATH}.data`
+const ERROR_PATH = `${PATH}.error`
 
 const reducer = (state={}, action) => {
   const handlers = {
-    ...setFromRequest(REQUEST_KEY, DATA_PATH)
+    ...setFromRequest(REQUEST_KEY, PATH)
   }
   const handler = handlers[action.type]
   return handler ? handler(state, action) : state
@@ -27,15 +29,17 @@ const [ requestAction, successAction, failureAction ] = request[LP_API].actions.
 
 test('setFromRequest ignores request actions', () => {
   const state = reducer({}, requestAction)
-  expect(get(DATA_PATH, state)).toEqual(undefined)
+  expect(get(PATH, state)).toEqual(undefined)
 })
 
-test('setFromRequest sets path to response on success', () => {
+test('setFromRequest sets data path to response on success', () => {
   const state = reducer({}, successAction)
   expect(get(DATA_PATH, state)).toEqual(responseBody)
+  expect(get(ERROR_PATH, state)).toEqual(undefined)
 })
 
-test('setFromRequest sets path to null on failure', () => {
+test('setFromRequest sets error path to error on failure', () => {
   const state = reducer({}, failureAction)
-  expect(get(DATA_PATH, state)).toEqual(null)
+  expect(get(ERROR_PATH, state)).toEqual(responseBody)
+  expect(get(DATA_PATH, state)).toEqual(undefined)
 })

--- a/test/set-from-request.test.js
+++ b/test/set-from-request.test.js
@@ -10,7 +10,7 @@ import { REQUEST_KEY } from './fixtures'
 
 /* HELPERS */
 
-const RESPONSE_PATH = 'path'
+const RESPONSE_PATH = 'path.to.response'
 
 const reducer = (state={}, action) => {
   const handlers = {

--- a/test/set-from-request.test.js
+++ b/test/set-from-request.test.js
@@ -1,0 +1,41 @@
+jest.mock('isomorphic-fetch')
+
+import { responseBody } from 'isomorphic-fetch'
+import { lpApiRequest, lpApiSuccess, lpApiFailure } from '../src/actions'
+import { get } from '../src/utils'
+import { setFromRequest } from '../src/'
+
+import { REQUEST_KEY } from './fixtures'
+
+
+/* HELPERS */
+
+const RESPONSE_PATH = 'path'
+
+const reducer = (state={}, action) => {
+  const handlers = {
+    ...setFromRequest(REQUEST_KEY, RESPONSE_PATH)
+  }
+  const handler = handlers[action.type]
+  return handler ? handler(state, action) : state
+}
+
+/* TESTS */
+
+test('setFromRequest ignores request actions', () => {
+  const requestAction = lpApiRequest(REQUEST_KEY)
+  const state = reducer({}, requestAction)
+  expect(get(RESPONSE_PATH, state)).toEqual(undefined)
+})
+
+test('setFromRequest sets path to response on success', () => {
+  const successAction = lpApiSuccess(REQUEST_KEY, responseBody)
+  const state = reducer({}, successAction)
+  expect(get(RESPONSE_PATH, state)).toEqual(responseBody)
+})
+
+test('setFromRequest sets path to null on failure', () => {
+  const failureAction = lpApiFailure(REQUEST_KEY)
+  const state = reducer({}, failureAction)
+  expect(get(RESPONSE_PATH, state)).toEqual(null)
+})

--- a/test/set-from-request.test.js
+++ b/test/set-from-request.test.js
@@ -1,41 +1,41 @@
 jest.mock('isomorphic-fetch')
 
 import { responseBody } from 'isomorphic-fetch'
-import { lpApiRequest, lpApiSuccess, lpApiFailure } from '../src/actions'
 import { get } from '../src/utils'
-import { setFromRequest } from '../src/'
+import { setFromRequest, requestWithKey, LP_API } from '../src/'
 
 import { REQUEST_KEY } from './fixtures'
 
-
 /* HELPERS */
 
-const RESPONSE_PATH = 'path'
+const DATA_PATH = 'path.to.data'
 
 const reducer = (state={}, action) => {
   const handlers = {
-    ...setFromRequest(REQUEST_KEY, RESPONSE_PATH)
+    ...setFromRequest(REQUEST_KEY, DATA_PATH)
   }
   const handler = handlers[action.type]
   return handler ? handler(state, action) : state
 }
 
+const request = requestWithKey(REQUEST_KEY)
+const [ requestAction, successAction, failureAction ] = request[LP_API].actions.map((type) => {
+  return { type, payload: responseBody }
+})
+
 /* TESTS */
 
 test('setFromRequest ignores request actions', () => {
-  const requestAction = lpApiRequest(REQUEST_KEY)
   const state = reducer({}, requestAction)
-  expect(get(RESPONSE_PATH, state)).toEqual(undefined)
+  expect(get(DATA_PATH, state)).toEqual(undefined)
 })
 
 test('setFromRequest sets path to response on success', () => {
-  const successAction = lpApiSuccess(REQUEST_KEY, responseBody)
   const state = reducer({}, successAction)
-  expect(get(RESPONSE_PATH, state)).toEqual(responseBody)
+  expect(get(DATA_PATH, state)).toEqual(responseBody)
 })
 
 test('setFromRequest sets path to null on failure', () => {
-  const failureAction = lpApiFailure(REQUEST_KEY)
   const state = reducer({}, failureAction)
-  expect(get(RESPONSE_PATH, state)).toEqual(null)
+  expect(get(DATA_PATH, state)).toEqual(null)
 })

--- a/test/set-from-request.test.js
+++ b/test/set-from-request.test.js
@@ -10,7 +10,7 @@ import { REQUEST_KEY } from './fixtures'
 
 /* HELPERS */
 
-const RESPONSE_PATH = 'path.to.response'
+const RESPONSE_PATH = 'path'
 
 const reducer = (state={}, action) => {
   const handlers = {


### PR DESCRIPTION
Given a request key and a path, `setFromRequest` generates an action handler that will set the state at that path to either:
- null (if the request fails)
- the response (if request succeeds)

Optional arg ideas (not implemented):
- transformation function for response
- default value for failed request