### PR TITLE
Return HTTPError object on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-redux-api",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "redux middleware and api library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -128,7 +128,7 @@ function validateOptions ({ url, actionTypes }) {
 function parseAction ({ action, payload={}, error=false }) {
   switch (typeof action) {
   // If it's an action creator, create the action
-  case 'function': return action(payload.response)
+  case 'function': return action(payload)
   // If it's an action object return the action
   case 'object': return action
   // Otherwise, create a "default" action object with the given type

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -83,11 +83,11 @@ export default function ({ onUnauthorized, ...options }) {
     // Make the request
     return http(url, requestOptions)
       .catch(error => {
-        const response = error.response || error.message || 'There was an error.'
+        const response = error
 
         // Send failure action to API reducer
         next(lpApiFailure(requestKey))
-        
+
         // Send user-specified failure action
         if (failureAction) {
           next(parseAction({
@@ -113,7 +113,7 @@ export default function ({ onUnauthorized, ...options }) {
             payload: { ...rest, response },
           }))
         }
-        
+
       })
   }
 }
@@ -135,5 +135,3 @@ function parseAction ({ action, payload={}, error=false }) {
   default: throw 'Invalid action definition (must be function, object or string).'
   }
 }
-
-

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -84,7 +84,7 @@ export default function ({ onUnauthorized, ...options }) {
     return http(url, requestOptions)
       .catch(error => {
         const response = error.response || error.message || 'There was an error.'
-        // const statusCode = error.status
+        const statusCode = error.status
 
         // Send failure action to API reducer
         next(lpApiFailure(requestKey))
@@ -93,7 +93,7 @@ export default function ({ onUnauthorized, ...options }) {
         if (failureAction) {
           next(parseAction({
             action: failureAction,
-            payload: { ...rest, response },
+            payload: { ...rest, response, statusCode },
             error: true,
           }))
         }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -84,7 +84,7 @@ export default function ({ onUnauthorized, ...options }) {
     return http(url, requestOptions)
       .catch(error => {
         const response = error.response || error.message || 'There was an error.'
-        const statusCode = error.status
+        // const statusCode = error.status
 
         // Send failure action to API reducer
         next(lpApiFailure(requestKey))
@@ -93,7 +93,7 @@ export default function ({ onUnauthorized, ...options }) {
         if (failureAction) {
           next(parseAction({
             action: failureAction,
-            payload: { ...rest, response, statusCode },
+            payload: { ...rest, response },
             error: true,
           }))
         }
@@ -111,7 +111,7 @@ export default function ({ onUnauthorized, ...options }) {
         if (successAction) {
           next(parseAction({
             action: successAction,
-            payload: { ...rest, response, status },
+            payload: { ...rest, response },
           }))
         }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -83,7 +83,8 @@ export default function ({ onUnauthorized, ...options }) {
     // Make the request
     return http(url, requestOptions)
       .catch(error => {
-        const response = error
+        const response = error.response || error.message || 'There was an error.'
+        const statusCode = error.status
 
         // Send failure action to API reducer
         next(lpApiFailure(requestKey))
@@ -92,7 +93,7 @@ export default function ({ onUnauthorized, ...options }) {
         if (failureAction) {
           next(parseAction({
             action: failureAction,
-            payload: { ...rest, response },
+            payload: { ...rest, response, statusCode },
             error: true,
           }))
         }
@@ -110,7 +111,7 @@ export default function ({ onUnauthorized, ...options }) {
         if (successAction) {
           next(parseAction({
             action: successAction,
-            payload: { ...rest, response },
+            payload: { ...rest, response, status },
           }))
         }
 


### PR DESCRIPTION
Noticed that we're not returning the status code on error, just the JSON response. Update to return full `HTTPError` object.

Credit to @dpikt :)