### PR TITLE
Set data from response key

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -8,7 +8,7 @@ export default function (state={}, { type, payload }) {
 }
 
 export function selectStatus (key, state, slice='api') {
-  if (!key || !state) throw 'Must include key and state params'
+  if (!key || !state) throw `Must include 'key' and 'state' arguments`
   if (!get(slice, state)) throw `No reducer exists at path '${slice}'`
   return get(`${slice}.${key}`, state)
 }

--- a/src/set-from-request.js
+++ b/src/set-from-request.js
@@ -1,10 +1,21 @@
 import { set, unset, compose } from './utils'
 
 export default function (requestKey, path) {
+  if (!requestKey || !path) throw `Must include 'requestKey' and 'path' arguments`
   const dataPath = `${path}.data`
   const errorPath = `${path}.error`
   return {
-    [`${requestKey}_SUCCESS`]: (state, action) => compose(set(dataPath, action.payload), unset(errorPath))(state),
-    [`${requestKey}_FAILURE`]: (state, action) => compose(set(errorPath, action.payload), unset(dataPath))(state)
+    [`${requestKey}_SUCCESS`]: (state, action) => {
+      return compose(
+        set(dataPath, action.payload.response),
+        unset(errorPath)
+      )(state)
+    },
+    [`${requestKey}_FAILURE`]: (state, action) => {
+      return compose(
+        set(errorPath, action.payload), 
+        unset(dataPath)
+      )(state)
+    }
   }
 }

--- a/test/set-from-request.test.js
+++ b/test/set-from-request.test.js
@@ -22,7 +22,7 @@ const reducer = (state={}, action) => {
 
 const request = requestWithKey(REQUEST_KEY)
 const [ requestAction, successAction, failureAction ] = request[LP_API].actions.map((type) => {
-  return { type, payload: responseBody }
+  return { type, payload: { response: responseBody } }
 })
 
 /* TESTS */
@@ -40,6 +40,6 @@ test('setFromRequest sets data path to response on success', () => {
 
 test('setFromRequest sets error path to error on failure', () => {
   const state = reducer({}, failureAction)
-  expect(get(ERROR_PATH, state)).toEqual(responseBody)
+  expect(get(ERROR_PATH, state)).toEqual({ response: responseBody})
   expect(get(DATA_PATH, state)).toEqual(undefined)
 })


### PR DESCRIPTION
So our states aren't nested too much. A temporary improvement until the `{ data, error }` backend change.