### PR TITLE
Return expected values from action promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-redux-api",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "redux middleware and api library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -119,6 +119,7 @@ function middleware (options={}) {
           }
           // Send success action to API reducer
           if (requestKey) next(actions.setStatusSuccess(requestKey, response))
+          return response
         },
         // Error handler
         error => {
@@ -134,6 +135,7 @@ function middleware (options={}) {
           if (requestKey) next(actions.setStatusFailure(requestKey, error))
           // Dispatch unauthorized action if applicable
           if (error.status === 401 && onUnauthorized) next(onUnauthorized())
+          throw error
         }
       )
   }

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -108,8 +108,9 @@ test('middleware dispatches success actions in the correct order', () => {
 })
 
 test('middleware dispatches failure actions in the correct order', () => {
+  expect.assertions(4)
   const store = mockStore({})
-  return store.dispatch(actionWithURL(failureUrl)).then(() => {
+  return store.dispatch(actionWithURL(failureUrl)).catch(() => {
     const dispatchedActions = store.getActions()
     // User defined REQUEST action
     expect(dispatchedActions[0].type).toEqual(ACTION_TYPE_REQUEST)
@@ -138,8 +139,9 @@ test('middleware dispatches success action when response body does not exist', (
 })
 
 test('middleware dispatches custom unauthorized action on auth error', () => {
+  expect.assertions(1)
   const store = mockStore({})
-  return store.dispatch(actionWithURL(unauthorizedUrl)).then(() => {
+  return store.dispatch(actionWithURL(unauthorizedUrl)).catch(() => {
     const dispatchedActions = store.getActions()
     expect(dispatchedActions.pop()).toEqual(UNAUTHORIZED_ACTION)
   })
@@ -154,8 +156,9 @@ test('middleware applies successDataPath correctly', () => {
 })
 
 test('middleware applies failureDataPath correctly', () => {
+  expect.assertions(1)
   const store = mockStore({})
-  return store.dispatch(actionWithURL(failureUrl)).then(() => {
+  return store.dispatch(actionWithURL(failureUrl)).catch(() => {
     const dispatchedActions = store.getActions()
     expect(dispatchedActions[2].payload.errors).toEqual(failureUrl)
   })


### PR DESCRIPTION
Make the promises returned from dispatched actions resolve/reject with expected values, allowing api actions to replace effects.