### PR TITLE
Fix typos related to v6 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Documentation and usage info can be found in [docs.md](docs.md).
 
 ## Migration Guides
 - [v5.0.0](migration-guides/v5.0.0.md)
-- [v6.0.0](migration-guides/v5.0.0.md)
+- [v6.0.0](migration-guides/v6.0.0.md)
 
 ## Contribution
 This package follows the Opex [NPM package guidelines](https://github.com/LaunchPadLab/opex/blob/master/gists/npm-package-guidelines.md). Please refer to the linked document for information on contributing, testing and versioning.

--- a/migration-guides/v6.0.0.md
+++ b/migration-guides/v6.0.0.md
@@ -3,7 +3,7 @@
 This version contains the following breaking changes:
 1. The middleware now requires an `adapter` to be initialized
 2. `requestWithKey` and `setFromRequest` have been removed
-3. `createStubRequest` has been renamed to `stubRequest`
+3. `stubRequest` has been renamed to `createStubRequest`
 
 ### Adapter
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-redux-api",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "redux middleware and api library",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
### Addresses
- Link to v6 on main README
- Flipped order of method naming