### PR TITLE
Add type attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-redux-api",
-  "version": "6.2.4",
+  "version": "6.3.0",
   "description": "redux middleware and api library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/create-request.js
+++ b/src/create-request.js
@@ -22,7 +22,7 @@ import { isObject, isFunction } from 'lodash'
  * // -> will make request to /users/5
  *
  * // Just like in redux-actions, this action can be referenced in a reducer by name:
- * 
+ *
  * handleActions({
  *    [apiActions.fetchUser]: (state, action) => ...
  * })
@@ -49,6 +49,7 @@ function createRequestWithMethod (type, definition, method) {
     }
   }
   actionCreator.toString = () => LP_API_ACTION_NAMESPACE + type
+  actionCreator.type = LP_API_ACTION_NAMESPACE + type
   return actionCreator
 }
 

--- a/test/create-request.test.js
+++ b/test/create-request.test.js
@@ -7,6 +7,7 @@ import {
   createPatchRequest,
   createDeleteRequest,
 } from '../src/'
+import { LP_API_ACTION_NAMESPACE } from '../src/actions'
 import { REQUEST_TYPE } from './fixtures'
 
 test('createRequest requires a type argument', () => {
@@ -34,6 +35,16 @@ test('createRequest accepts function request definitions', () => {
 
 test('createRequest rejects other types of request definitions', () => {
   expect(() => createRequest(REQUEST_TYPE, 'wtf')).toThrow()
+})
+
+test('createRequest has the namespaced action type as its string representation', () => {
+  const actionCreator = createRequest(REQUEST_TYPE, {})
+  expect(actionCreator.toString()).toEqual(LP_API_ACTION_NAMESPACE+REQUEST_TYPE)
+})
+
+test('createRequest has the namespaced action type set to the special `type` property', () => {
+  const actionCreator = createRequest(REQUEST_TYPE, {})
+  expect(actionCreator.type).toEqual(LP_API_ACTION_NAMESPACE+REQUEST_TYPE)
 })
 
 // Convenience functions


### PR DESCRIPTION
Resolves #155 in support of https://github.com/LaunchPadLab/client-template/pull/439.

This is very similar to the default action creator logic: https://github.com/reduxjs/redux-toolkit/blob/24fc34392d249573fd14088db8daea10e848de41/packages/toolkit/src/createAction.ts#L280-L282